### PR TITLE
fix: call to a member function uuid() on null

### DIFF
--- a/access_token.module
+++ b/access_token.module
@@ -94,7 +94,7 @@ function access_token_generate_access_token(EntityInterface $entity = NULL) {
   }
 
   $access_token = '';
-  if ($entity->uuid()) {
+  if ($entity instanceof EntityInterface && $entity->uuid()) {
     // generate access token based on a few variables
     $data = [
       'route_name' => $entity->toUrl('canonical')->getRouteName(),
@@ -135,7 +135,7 @@ function access_token_get_current_page_entity() {
     }
   }
 
-  // If no entity found stop searching next time this get's called
+  // If no entity found stop searching next time this gets called
   if ($entity == FALSE) {
     $entity = NULL;
   }
@@ -148,7 +148,6 @@ function access_token_get_current_page_entity() {
  *
  * @param Drupal\Core\Entity\EntityInterface $entity
  * @param Drupal\Core\Entity\EntityInterface$container
- * $param int $recursivity_level
  *
  * @return bool
  *  TRUE if the $container entity has references to $entity or false otherwise


### PR DESCRIPTION
## Steps to reproduce

Create a node with a view that is embedded and uses ajax (e.g. with a filter).
Use the access token link.

Ajax calls are getting the access token like `/views/ajax?access_token=<token>` which causes 

```
Error: Call to a member function uuid() on null in access_token_generate_access_token() 
```

so it breaks ajax views and possibly other features.

## Proposed resolution

A trivial / non breaking change fix is to check the entity before getting the uuid.